### PR TITLE
Refine .gitignore and remove generated PWA public assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+.DS_Store
+.env
+.env.*
+
+# Go
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.test
+*.out
+bin/
+dist/
+build/
+coverage/
+tmp/
+*.log
+
+# Frontend
+node_modules/
+**/node_modules/
+frontend/dist/
+.next/
+.cache/
+.parcel-cache/
+public/
+
+# IDE
+.idea/
+.vscode/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.22-alpine AS build
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -o server ./cmd/server
+
+FROM alpine:3.20
+WORKDIR /app
+COPY --from=build /app/server /app/server
+EXPOSE 8080
+CMD ["/app/server"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,74 @@
+# FireGoals MVP
+
+FireGoals is a cross-platform PWA for goals, tasks, fire currency, rewards, and achievements with workspace collaboration.
+
+## Stack
+
+- Backend: Go + Postgres (Neon)
+- Frontend: React + Vite + TypeScript (PWA)
+- Deploy: Render (backend) + Cloudflare Pages (frontend)
+
+## Local Development
+
+### Backend
+
+```bash
+export DATABASE_URL=postgresql://user:pass@host/db
+export JWT_SECRET=your-secret
+export PORT=8080
+
+go run ./cmd/server
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## Database Setup (Neon)
+
+1. Create a Neon project and database.
+2. Copy the connection string and set `DATABASE_URL`.
+3. Run migrations:
+
+```bash
+psql "$DATABASE_URL" -f migrations/0001_init.sql
+```
+
+## Deployment
+
+### Render (Backend)
+
+1. Create a new Web Service.
+2. Use Docker build.
+3. Set environment variables:
+   - `DATABASE_URL`
+   - `JWT_SECRET`
+   - `PORT` (optional; Render sets it automatically)
+4. Health check: `/health`.
+
+### Cloudflare Pages (Frontend)
+
+- Build command: `npm run build`
+- Output directory: `dist`
+- Environment: `VITE_API_URL` (point to Render backend)
+
+## Environment Variables
+
+Backend:
+- `DATABASE_URL`
+- `JWT_SECRET`
+- `PORT`
+
+Frontend:
+- `VITE_API_URL`
+
+## API Notes
+
+- All authenticated requests require `Authorization: Bearer <token>`.
+- Sync endpoints:
+  - `GET /sync?workspace_id=...&since=RFC3339`
+  - `POST /sync` with `{ workspace_id, changes }`

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"firegoals/internal/auth"
+	"firegoals/internal/config"
+	"firegoals/internal/db"
+	api "firegoals/internal/http"
+	"firegoals/internal/repo"
+	"firegoals/internal/service"
+)
+
+func main() {
+	cfg := config.Load()
+	ctx := context.Background()
+	pool, err := db.NewPool(ctx, cfg.DatabaseURL)
+	if err != nil {
+		log.Fatalf("failed to connect db: %v", err)
+	}
+	defer pool.Close()
+
+	authManager := auth.NewManager(cfg.JWTSecret)
+	repository := repo.New(pool)
+	svc := service.New(repository, authManager)
+
+	handler := &api.API{Repo: repository, Service: svc, Auth: authManager}
+
+	srv := &http.Server{
+		Addr:              ":" + cfg.Port,
+		Handler:           handler.Router(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() {
+		log.Printf("server listening on %s", cfg.Port)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("server error: %v", err)
+		}
+	}()
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
+	<-stop
+
+	ctxShutdown, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctxShutdown); err != nil {
+		log.Printf("server shutdown error: %v", err)
+	}
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>FireGoals</title>
+    <meta name="theme-color" content="#ff7a18" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "firegoals-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "localforage": "^1.10.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "typescript": "^5.5.3",
+    "vite": "^5.3.4"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,357 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  addAchievement,
+  addReward,
+  addTask,
+  buyReward,
+  completeTask,
+  fetchWorkspaceBalance,
+  getMe,
+  listWorkspaces,
+  login,
+  register,
+  runSyncPull,
+  runSyncPush,
+  syncChanges,
+  updateLocalCache
+} from "./api";
+import {
+  Achievement,
+  Reward,
+  Task,
+  WorkspaceSnapshot,
+  emptySnapshot,
+  loadSnapshot,
+  saveSnapshot
+} from "./storage";
+
+const tabs = ["Today", "Plans", "Store", "Achievements", "Settings"] as const;
+
+type Tab = (typeof tabs)[number];
+
+export default function App() {
+  const [activeTab, setActiveTab] = useState<Tab>("Today");
+  const [snapshot, setSnapshot] = useState<WorkspaceSnapshot>(emptySnapshot());
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [status, setStatus] = useState<string | null>(null);
+  const [balance, setBalance] = useState<number>(0);
+
+  useEffect(() => {
+    loadSnapshot().then((data) => {
+      setSnapshot(data);
+    });
+  }, []);
+
+  const todayTasks = useMemo(
+    () => snapshot.tasks.filter((task) => !task.deleted_at && task.status !== "done"),
+    [snapshot.tasks]
+  );
+
+  async function handleAuth(action: "login" | "register") {
+    setStatus(null);
+    try {
+      if (action === "register") {
+        await register(email, password);
+      }
+      await login(email, password);
+      const me = await getMe();
+      const workspaceID = await listWorkspaces();
+      const nextSnapshot = { ...snapshot, user: me, workspaceId: workspaceID };
+      setSnapshot(nextSnapshot);
+      await saveSnapshot(nextSnapshot);
+      await refreshBalance(workspaceID);
+      setStatus("Авторизация успешна");
+    } catch (error) {
+      setStatus("Не удалось авторизоваться");
+    }
+  }
+
+  async function handleSync() {
+    if (!snapshot.workspaceId) {
+      setStatus("Сначала войдите в аккаунт");
+      return;
+    }
+    setStatus("Синхронизация...");
+    try {
+      await runSyncPush(snapshot);
+      const updated = await runSyncPull(snapshot);
+      setSnapshot(updated);
+      await saveSnapshot(updated);
+      await refreshBalance(updated.workspaceId);
+      setStatus("Синхронизация завершена");
+    } catch (error) {
+      setStatus("Ошибка синхронизации");
+    }
+  }
+
+  async function refreshBalance(workspaceId: string) {
+    const data = await fetchWorkspaceBalance(workspaceId);
+    setBalance(data.balance);
+  }
+
+  async function handleAddTask(form: { title: string; value: number; dueDate: string }) {
+    if (!snapshot.workspaceId) return;
+    const task = await addTask(snapshot.workspaceId, form);
+    const updated = updateLocalCache(snapshot, { tasks: [task] });
+    setSnapshot(updated);
+    await saveSnapshot(updated);
+  }
+
+  async function handleCompleteTask(task: Task) {
+    if (!snapshot.workspaceId) return;
+    await completeTask(snapshot.workspaceId, task.id);
+    const updated = updateLocalCache(snapshot, {
+      tasks: snapshot.tasks.map((item) =>
+        item.id === task.id
+          ? { ...item, status: "done", done_at: new Date().toISOString() }
+          : item
+      )
+    });
+    setSnapshot(updated);
+    await saveSnapshot(updated);
+    await refreshBalance(snapshot.workspaceId);
+  }
+
+  async function handleAddReward(form: { title: string; cost: number; description: string }) {
+    if (!snapshot.workspaceId) return;
+    const reward = await addReward(snapshot.workspaceId, form);
+    const updated = updateLocalCache(snapshot, { rewards: [reward] });
+    setSnapshot(updated);
+    await saveSnapshot(updated);
+  }
+
+  async function handleBuyReward(reward: Reward) {
+    if (!snapshot.workspaceId) return;
+    await syncChanges(snapshot.workspaceId, { rewards: [] });
+    await buyReward(snapshot.workspaceId, reward.id);
+    await refreshBalance(snapshot.workspaceId);
+  }
+
+  async function handleAddAchievement(form: { title: string; description: string }) {
+    if (!snapshot.workspaceId) return;
+    const achievement = await addAchievement(snapshot.workspaceId, form);
+    const updated = updateLocalCache(snapshot, { achievements: [achievement] });
+    setSnapshot(updated);
+    await saveSnapshot(updated);
+  }
+
+  return (
+    <div className="app">
+      <header className="app__header">
+        <div>
+          <h1>FireGoals</h1>
+          <p className="muted">Цели, задачи и огоньки</p>
+        </div>
+        <div className="balance">
+          <span>Огоньки</span>
+          <strong>{balance.toFixed(2)}</strong>
+        </div>
+      </header>
+      <nav className="app__nav">
+        {tabs.map((tab) => (
+          <button
+            key={tab}
+            className={tab === activeTab ? "active" : ""}
+            onClick={() => setActiveTab(tab)}
+          >
+            {tab}
+          </button>
+        ))}
+      </nav>
+      <main className="app__main">
+        {activeTab === "Today" && (
+          <section className="card">
+            <h2>Сегодня</h2>
+            <TaskForm onAdd={handleAddTask} />
+            <ul className="list">
+              {todayTasks.map((task) => (
+                <li key={task.id} className="list__item">
+                  <div>
+                    <p>{task.title}</p>
+                    <span className="muted">+{task.value} огоньков</span>
+                  </div>
+                  <button onClick={() => handleCompleteTask(task)}>Готово</button>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+        {activeTab === "Plans" && (
+          <section className="card">
+            <h2>Планы</h2>
+            <p className="muted">Добавляйте цели и задачи на неделю, месяц или год.</p>
+            <p>В скором времени появится детальная планировка.</p>
+          </section>
+        )}
+        {activeTab === "Store" && (
+          <section className="card">
+            <h2>Магазин наград</h2>
+            <RewardForm onAdd={handleAddReward} />
+            <ul className="list">
+              {snapshot.rewards.map((reward) => (
+                <li key={reward.id} className="list__item">
+                  <div>
+                    <p>{reward.title}</p>
+                    <span className="muted">{reward.cost} огоньков</span>
+                  </div>
+                  <button onClick={() => handleBuyReward(reward)}>Купить</button>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+        {activeTab === "Achievements" && (
+          <section className="card">
+            <h2>Достижения</h2>
+            <AchievementForm onAdd={handleAddAchievement} />
+            <ul className="list">
+              {snapshot.achievements.map((achievement) => (
+                <li key={achievement.id} className="list__item">
+                  <div>
+                    <p>{achievement.title}</p>
+                    <span className="muted">{achievement.description}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+        {activeTab === "Settings" && (
+          <section className="card">
+            <h2>Профиль и синхронизация</h2>
+            <div className="auth">
+              <input
+                type="email"
+                placeholder="Email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+              />
+              <input
+                type="password"
+                placeholder="Пароль"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+              />
+              <div className="auth__actions">
+                <button onClick={() => handleAuth("login")}>Войти</button>
+                <button className="secondary" onClick={() => handleAuth("register")}>
+                  Регистрация
+                </button>
+              </div>
+            </div>
+            <button className="full" onClick={handleSync}>
+              Синхронизировать сейчас
+            </button>
+            {status && <p className="muted">{status}</p>}
+          </section>
+        )}
+      </main>
+    </div>
+  );
+}
+
+function TaskForm({ onAdd }: { onAdd: (data: { title: string; value: number; dueDate: string }) => void }) {
+  const [title, setTitle] = useState("");
+  const [value, setValue] = useState(10);
+  const [dueDate, setDueDate] = useState("");
+
+  return (
+    <div className="form">
+      <input
+        value={title}
+        placeholder="Название задачи"
+        onChange={(event) => setTitle(event.target.value)}
+      />
+      <input
+        type="number"
+        value={value}
+        onChange={(event) => setValue(Number(event.target.value))}
+      />
+      <input type="date" value={dueDate} onChange={(event) => setDueDate(event.target.value)} />
+      <button
+        onClick={() => {
+          if (title) {
+            onAdd({ title, value, dueDate });
+            setTitle("");
+            setDueDate("");
+          }
+        }}
+      >
+        Добавить
+      </button>
+    </div>
+  );
+}
+
+function RewardForm({
+  onAdd
+}: {
+  onAdd: (data: { title: string; cost: number; description: string }) => void;
+}) {
+  const [title, setTitle] = useState("");
+  const [cost, setCost] = useState(30);
+  const [description, setDescription] = useState("");
+
+  return (
+    <div className="form">
+      <input
+        value={title}
+        placeholder="Награда"
+        onChange={(event) => setTitle(event.target.value)}
+      />
+      <input type="number" value={cost} onChange={(event) => setCost(Number(event.target.value))} />
+      <input
+        value={description}
+        placeholder="Описание"
+        onChange={(event) => setDescription(event.target.value)}
+      />
+      <button
+        onClick={() => {
+          if (title) {
+            onAdd({ title, cost, description });
+            setTitle("");
+            setDescription("");
+          }
+        }}
+      >
+        Добавить
+      </button>
+    </div>
+  );
+}
+
+function AchievementForm({
+  onAdd
+}: {
+  onAdd: (data: { title: string; description: string }) => void;
+}) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+
+  return (
+    <div className="form">
+      <input
+        value={title}
+        placeholder="Достижение"
+        onChange={(event) => setTitle(event.target.value)}
+      />
+      <input
+        value={description}
+        placeholder="Описание"
+        onChange={(event) => setDescription(event.target.value)}
+      />
+      <button
+        onClick={() => {
+          if (title) {
+            onAdd({ title, description });
+            setTitle("");
+            setDescription("");
+          }
+        }}
+      >
+        Добавить
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,177 @@
+import { Achievement, Reward, Task, WorkspaceSnapshot } from "./storage";
+
+const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:8080";
+
+function getToken(): string | null {
+  return localStorage.getItem("firegoals-token");
+}
+
+function setToken(token: string) {
+  localStorage.setItem("firegoals-token", token);
+}
+
+async function apiFetch(path: string, options: RequestInit = {}) {
+  const token = getToken();
+  const headers = new Headers(options.headers ?? {});
+  headers.set("Content-Type", "application/json");
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+  const response = await fetch(`${API_URL}${path}`, { ...options, headers });
+  if (!response.ok) {
+    throw new Error(`Request failed: ${response.status}`);
+  }
+  return response.json();
+}
+
+export async function register(email: string, password: string) {
+  await apiFetch("/auth/register", {
+    method: "POST",
+    body: JSON.stringify({ email, password })
+  });
+}
+
+export async function login(email: string, password: string) {
+  const data = await apiFetch("/auth/login", {
+    method: "POST",
+    body: JSON.stringify({ email, password })
+  });
+  setToken(data.access_token);
+}
+
+export async function getMe() {
+  return apiFetch("/me");
+}
+
+export async function listWorkspaces(): Promise<string> {
+  const data = await apiFetch("/workspaces");
+  return data.workspaces[0];
+}
+
+export async function fetchWorkspaceBalance(workspaceId: string) {
+  return apiFetch(`/workspaces/${workspaceId}/balance`);
+}
+
+export async function addTask(
+  workspaceId: string,
+  form: { title: string; value: number; dueDate: string }
+): Promise<Task> {
+  const payload = {
+    workspace_id: workspaceId,
+    title: form.title,
+    value: form.value,
+    due_date: form.dueDate || null,
+    status: "open",
+    description: ""
+  };
+  const data = await apiFetch("/tasks", { method: "POST", body: JSON.stringify(payload) });
+  return {
+    id: data.id,
+    workspace_id: workspaceId,
+    title: form.title,
+    description: "",
+    due_date: form.dueDate || null,
+    value: form.value,
+    status: "open"
+  };
+}
+
+export async function completeTask(workspaceId: string, taskId: string) {
+  await apiFetch(`/tasks/${taskId}/complete`, {
+    method: "POST",
+    body: JSON.stringify({ workspace_id: workspaceId })
+  });
+}
+
+export async function addReward(
+  workspaceId: string,
+  form: { title: string; cost: number; description: string }
+): Promise<Reward> {
+  const payload = {
+    workspace_id: workspaceId,
+    title: form.title,
+    description: form.description,
+    cost: form.cost,
+    is_shared: false
+  };
+  const data = await apiFetch("/rewards", { method: "POST", body: JSON.stringify(payload) });
+  return {
+    id: data.id,
+    workspace_id: workspaceId,
+    title: form.title,
+    description: form.description,
+    cost: form.cost
+  };
+}
+
+export async function buyReward(workspaceId: string, rewardId: string) {
+  await apiFetch(`/rewards/${rewardId}/buy`, {
+    method: "POST",
+    body: JSON.stringify({ workspace_id: workspaceId })
+  });
+}
+
+export async function addAchievement(
+  workspaceId: string,
+  form: { title: string; description: string }
+): Promise<Achievement> {
+  const payload = {
+    workspace_id: workspaceId,
+    title: form.title,
+    description: form.description
+  };
+  const data = await apiFetch("/achievements", { method: "POST", body: JSON.stringify(payload) });
+  return {
+    id: data.id,
+    workspace_id: workspaceId,
+    title: form.title,
+    description: form.description
+  };
+}
+
+export function updateLocalCache(snapshot: WorkspaceSnapshot, updates: Partial<WorkspaceSnapshot>) {
+  return {
+    ...snapshot,
+    ...updates,
+    tasks: [...(updates.tasks ?? []), ...snapshot.tasks],
+    rewards: [...(updates.rewards ?? []), ...snapshot.rewards],
+    achievements: [...(updates.achievements ?? []), ...snapshot.achievements]
+  };
+}
+
+export async function runSyncPull(snapshot: WorkspaceSnapshot): Promise<WorkspaceSnapshot> {
+  if (!snapshot.workspaceId) return snapshot;
+  const since = snapshot.lastSync ?? new Date(0).toISOString();
+  const data = await apiFetch(`/sync?workspace_id=${snapshot.workspaceId}&since=${since}`);
+  const changes = data.changes ?? {};
+  const updated: WorkspaceSnapshot = {
+    ...snapshot,
+    tasks: mergeEntities(snapshot.tasks, changes.tasks ?? []),
+    rewards: mergeEntities(snapshot.rewards, changes.rewards ?? []),
+    achievements: mergeEntities(snapshot.achievements, changes.achievements ?? []),
+    lastSync: new Date().toISOString()
+  };
+  return updated;
+}
+
+export async function runSyncPush(snapshot: WorkspaceSnapshot) {
+  if (!snapshot.workspaceId) return;
+  await syncChanges(snapshot.workspaceId, {
+    tasks: snapshot.tasks,
+    rewards: snapshot.rewards,
+    achievements: snapshot.achievements
+  });
+}
+
+export async function syncChanges(workspaceId: string, changes: Record<string, unknown>) {
+  await apiFetch("/sync", {
+    method: "POST",
+    body: JSON.stringify({ workspace_id: workspaceId, changes })
+  });
+}
+
+function mergeEntities<T extends { id: string }>(current: T[], incoming: T[]): T[] {
+  const map = new Map(current.map((item) => [item.id, item]));
+  incoming.forEach((item) => map.set(item.id, item));
+  return Array.from(map.values());
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,160 @@
+:root {
+  font-family: "Inter", system-ui, sans-serif;
+  color: #f5f5f5;
+  background: #0f0f11;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #0f0f11, #1b1b22);
+}
+
+.app {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.app__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #15151c;
+  padding: 16px 20px;
+  border-radius: 16px;
+}
+
+.app__nav {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px;
+}
+
+.app__nav button {
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: none;
+  background: #1f1f2b;
+  color: inherit;
+  cursor: pointer;
+}
+
+.app__nav button.active {
+  background: #ff7a18;
+  color: #1b0b00;
+  font-weight: 600;
+}
+
+.app__main {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card {
+  background: #16161f;
+  padding: 20px;
+  border-radius: 16px;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.2);
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 16px 0 0;
+  display: grid;
+  gap: 12px;
+}
+
+.list__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: #1f1f2b;
+  padding: 12px 16px;
+  border-radius: 12px;
+}
+
+.form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 8px;
+  margin-top: 12px;
+}
+
+input {
+  background: #1f1f2b;
+  color: inherit;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+button {
+  border: none;
+  border-radius: 10px;
+  padding: 10px 14px;
+  cursor: pointer;
+  background: #ff7a18;
+  color: #1b0b00;
+  font-weight: 600;
+}
+
+button.secondary {
+  background: #2a2a3a;
+  color: #f5f5f5;
+}
+
+button.full {
+  width: 100%;
+  margin-top: 12px;
+}
+
+.balance {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 4px;
+}
+
+.auth {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.auth__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.muted {
+  color: #a1a1b2;
+  font-size: 0.9rem;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    color: #1f1f2b;
+    background: #f5f5f5;
+  }
+
+  body {
+    background: #f5f5f5;
+  }
+
+  .app__header,
+  .card {
+    background: white;
+  }
+
+  .list__item,
+  input,
+  .app__nav button {
+    background: #f3f3f6;
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+const root = document.getElementById("root");
+if (root) {
+  ReactDOM.createRoot(root).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+}

--- a/frontend/src/storage.ts
+++ b/frontend/src/storage.ts
@@ -1,0 +1,73 @@
+export type Task = {
+  id: string;
+  workspace_id: string;
+  title: string;
+  description: string;
+  due_date?: string | null;
+  value: number;
+  status: string;
+  done_at?: string | null;
+  deleted_at?: string | null;
+  updated_at?: string;
+  version?: number;
+};
+
+export type Reward = {
+  id: string;
+  workspace_id: string;
+  title: string;
+  description: string;
+  cost: number;
+  deleted_at?: string | null;
+  updated_at?: string;
+  version?: number;
+};
+
+export type Achievement = {
+  id: string;
+  workspace_id: string;
+  title: string;
+  description: string;
+  image_url?: string | null;
+  deleted_at?: string | null;
+  updated_at?: string;
+  version?: number;
+};
+
+export type WorkspaceSnapshot = {
+  user?: { id: string; email: string } | null;
+  workspaceId?: string | null;
+  tasks: Task[];
+  rewards: Reward[];
+  achievements: Achievement[];
+  lastSync?: string | null;
+};
+
+const STORAGE_KEY = "firegoals-snapshot";
+
+export function emptySnapshot(): WorkspaceSnapshot {
+  return {
+    tasks: [],
+    rewards: [],
+    achievements: [],
+    lastSync: null,
+    user: null,
+    workspaceId: null
+  };
+}
+
+export async function loadSnapshot(): Promise<WorkspaceSnapshot> {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) {
+    return emptySnapshot();
+  }
+  try {
+    return JSON.parse(raw) as WorkspaceSnapshot;
+  } catch (error) {
+    return emptySnapshot();
+  }
+}
+
+export async function saveSnapshot(snapshot: WorkspaceSnapshot): Promise<void> {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(snapshot));
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module firegoals
+
+go 1.22
+
+require (
+	github.com/go-chi/chi/v5 v5.0.10
+	github.com/golang-jwt/jwt/v5 v5.2.1
+	github.com/jackc/pgx/v5 v5.5.5
+	golang.org/x/crypto v0.23.0
+)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,88 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/crypto/bcrypt"
+)
+
+type Claims struct {
+	UserID string `json:"user_id"`
+	jwt.RegisteredClaims
+}
+
+type Manager struct {
+	Secret []byte
+}
+
+func NewManager(secret string) *Manager {
+	return &Manager{Secret: []byte(secret)}
+}
+
+func (m *Manager) HashPassword(password string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+	return string(hash), nil
+}
+
+func (m *Manager) ComparePassword(hash, password string) error {
+	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
+}
+
+func (m *Manager) GenerateToken(userID string, ttl time.Duration) (string, error) {
+	claims := Claims{
+		UserID: userID,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(ttl)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+		},
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString(m.Secret)
+}
+
+func (m *Manager) ParseToken(tokenString string) (*Claims, error) {
+	parsed, err := jwt.ParseWithClaims(tokenString, &Claims{}, func(token *jwt.Token) (interface{}, error) {
+		return m.Secret, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	claims, ok := parsed.Claims.(*Claims)
+	if !ok || !parsed.Valid {
+		return nil, errors.New("invalid token")
+	}
+	return claims, nil
+}
+
+func TokenFromRequest(r *http.Request) (string, bool) {
+	header := r.Header.Get("Authorization")
+	if header == "" {
+		return "", false
+	}
+	parts := strings.SplitN(header, " ", 2)
+	if len(parts) != 2 || strings.ToLower(parts[0]) != "bearer" {
+		return "", false
+	}
+	return parts[1], true
+}
+
+type contextKey string
+
+const userIDKey contextKey = "userID"
+
+func WithUserID(ctx context.Context, userID string) context.Context {
+	return context.WithValue(ctx, userIDKey, userID)
+}
+
+func UserIDFromContext(ctx context.Context) (string, bool) {
+	userID, ok := ctx.Value(userIDKey).(string)
+	return userID, ok
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"log"
+	"os"
+)
+
+type Config struct {
+	DatabaseURL string
+	JWTSecret   string
+	Port        string
+	CORSOrigin  string
+}
+
+func Load() Config {
+	cfg := Config{
+		DatabaseURL: os.Getenv("DATABASE_URL"),
+		JWTSecret:   os.Getenv("JWT_SECRET"),
+		Port:        os.Getenv("PORT"),
+		CORSOrigin:  os.Getenv("CORS_ORIGIN"),
+	}
+	if cfg.Port == "" {
+		cfg.Port = "8080"
+	}
+	if cfg.JWTSecret == "" {
+		log.Fatal("JWT_SECRET is required")
+	}
+	if cfg.DatabaseURL == "" {
+		log.Fatal("DATABASE_URL is required")
+	}
+	if cfg.CORSOrigin == "" {
+		cfg.CORSOrigin = "*"
+	}
+	return cfg
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,0 +1,19 @@
+package db
+
+import (
+	"context"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func NewPool(ctx context.Context, databaseURL string) (*pgxpool.Pool, error) {
+	config, err := pgxpool.ParseConfig(databaseURL)
+	if err != nil {
+		return nil, err
+	}
+	config.MaxConns = 10
+	config.MinConns = 2
+	config.MaxConnIdleTime = 5 * time.Minute
+	return pgxpool.NewWithConfig(ctx, config)
+}

--- a/internal/http/handlers.go
+++ b/internal/http/handlers.go
@@ -1,0 +1,712 @@
+package http
+
+import (
+	"encoding/base32"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"firegoals/internal/auth"
+	"firegoals/internal/repo"
+
+	"github.com/go-chi/chi/v5"
+)
+
+type registerRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+type loginResponse struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+}
+
+type workspaceRequest struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+type inviteRequest struct {
+	Code string `json:"code"`
+}
+
+type entityResponse struct {
+	ID string `json:"id"`
+}
+
+type goalRequest struct {
+	WorkspaceID string     `json:"workspace_id"`
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	Period      string     `json:"period"`
+	StartDate   *time.Time `json:"start_date"`
+	EndDate     *time.Time `json:"end_date"`
+	Status      string     `json:"status"`
+}
+
+type taskRequest struct {
+	WorkspaceID string     `json:"workspace_id"`
+	GoalID      *string    `json:"goal_id"`
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	DueDate     *time.Time `json:"due_date"`
+	RepeatRule  *string    `json:"repeat_rule"`
+	Value       float64    `json:"value"`
+	Status      string     `json:"status"`
+}
+
+type rewardRequest struct {
+	WorkspaceID   string  `json:"workspace_id"`
+	Title         string  `json:"title"`
+	Description   string  `json:"description"`
+	Cost          float64 `json:"cost"`
+	IsShared      bool    `json:"is_shared"`
+	CooldownHours *int    `json:"cooldown_hours"`
+}
+
+type achievementRequest struct {
+	WorkspaceID string     `json:"workspace_id"`
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	ImageURL    *string    `json:"image_url"`
+	AchievedAt  *time.Time `json:"achieved_at"`
+}
+
+type workspaceBalanceResponse struct {
+	WorkspaceID string  `json:"workspace_id"`
+	Balance     float64 `json:"balance"`
+}
+
+type syncPushRequest struct {
+	WorkspaceID string                      `json:"workspace_id"`
+	Changes     map[string][]map[string]any `json:"changes"`
+}
+
+func (a *API) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (a *API) handleRegister(w http.ResponseWriter, r *http.Request) {
+	var req registerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid payload")
+		return
+	}
+	if req.Email == "" || req.Password == "" {
+		writeError(w, http.StatusBadRequest, "email and password required")
+		return
+	}
+	userID, err := a.Service.Register(r.Context(), req.Email, req.Password)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, entityResponse{ID: userID})
+}
+
+func (a *API) handleLogin(w http.ResponseWriter, r *http.Request) {
+	var req registerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid payload")
+		return
+	}
+	accessToken, refreshToken, err := a.Service.Login(r.Context(), req.Email, req.Password)
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "invalid credentials")
+		return
+	}
+	writeJSON(w, http.StatusOK, loginResponse{AccessToken: accessToken, RefreshToken: refreshToken})
+}
+
+func (a *API) handleMe(w http.ResponseWriter, r *http.Request) {
+	userID, ok := auth.UserIDFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "missing user")
+		return
+	}
+	id, email, err := a.Repo.GetUserByID(r.Context(), userID)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "user not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"id": id, "email": email})
+}
+
+func (a *API) handleListWorkspaces(w http.ResponseWriter, r *http.Request) {
+	userID, ok := auth.UserIDFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "missing user")
+		return
+	}
+	ids, err := a.Repo.ListUserWorkspaces(r.Context(), userID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list workspaces")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"workspaces": ids})
+}
+
+func (a *API) handleCreateWorkspace(w http.ResponseWriter, r *http.Request) {
+	userID, ok := auth.UserIDFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "missing user")
+		return
+	}
+	var req workspaceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid payload")
+		return
+	}
+	if req.Name == "" {
+		writeError(w, http.StatusBadRequest, "name required")
+		return
+	}
+	workspaceType := req.Type
+	if workspaceType == "" {
+		workspaceType = "shared"
+	}
+	id, err := a.Repo.CreateWorkspace(r.Context(), req.Name, workspaceType, userID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create workspace")
+		return
+	}
+	writeJSON(w, http.StatusCreated, entityResponse{ID: id})
+}
+
+func (a *API) handleWorkspaceBalance(w http.ResponseWriter, r *http.Request) {
+	workspaceID := chi.URLParam(r, "id")
+	userID, ok := auth.UserIDFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "missing user")
+		return
+	}
+	allowed, err := a.Repo.UserInWorkspace(r.Context(), userID, workspaceID)
+	if err != nil || !allowed {
+		writeError(w, http.StatusForbidden, "not allowed")
+		return
+	}
+	balance, err := a.Repo.GetWorkspaceBalance(r.Context(), workspaceID)
+	if err != nil {
+		writeError(w, http.StatusNotFound, "balance not found")
+		return
+	}
+	writeJSON(w, http.StatusOK, workspaceBalanceResponse{WorkspaceID: workspaceID, Balance: balance})
+}
+
+func (a *API) handleCreateInvite(w http.ResponseWriter, r *http.Request) {
+	workspaceID := chi.URLParam(r, "id")
+	userID, ok := auth.UserIDFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "missing user")
+		return
+	}
+	allowed, err := a.Repo.UserInWorkspace(r.Context(), userID, workspaceID)
+	if err != nil || !allowed {
+		writeError(w, http.StatusForbidden, "not allowed")
+		return
+	}
+	code := randomCode()
+	expiresAt := time.Now().Add(48 * time.Hour)
+	if err := a.Repo.CreateInvite(r.Context(), workspaceID, userID, code, expiresAt); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create invite")
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]any{"code": code, "expires_at": expiresAt})
+}
+
+func (a *API) handleAcceptInvite(w http.ResponseWriter, r *http.Request) {
+	userID, ok := auth.UserIDFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "missing user")
+		return
+	}
+	var req inviteRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid payload")
+		return
+	}
+	if req.Code == "" {
+		writeError(w, http.StatusBadRequest, "code required")
+		return
+	}
+	workspaceID, expiresAt, err := a.Repo.GetInvite(r.Context(), req.Code)
+	if err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "invite not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to accept invite")
+		return
+	}
+	if time.Now().After(expiresAt) {
+		writeError(w, http.StatusBadRequest, "invite expired")
+		return
+	}
+	if err := a.Repo.AddWorkspaceMember(r.Context(), workspaceID, userID, "member"); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to join workspace")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"workspace_id": workspaceID})
+}
+
+func (a *API) handleListGoals(w http.ResponseWriter, r *http.Request) {
+	workspaceID := r.URL.Query().Get("workspace_id")
+	if !a.authorizeWorkspace(w, r, workspaceID) {
+		return
+	}
+	goals, err := a.Repo.ListGoals(r.Context(), workspaceID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list goals")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"goals": goals})
+}
+
+func (a *API) handleCreateGoal(w http.ResponseWriter, r *http.Request) {
+	var req goalRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid payload")
+		return
+	}
+	if req.Title == "" || req.WorkspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace_id and title required")
+		return
+	}
+	if !a.authorizeWorkspace(w, r, req.WorkspaceID) {
+		return
+	}
+	status := req.Status
+	if status == "" {
+		status = "active"
+	}
+	id, err := a.Repo.CreateGoal(r.Context(), req.WorkspaceID, req.Title, req.Description, req.Period, status, req.StartDate, req.EndDate)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create goal")
+		return
+	}
+	writeJSON(w, http.StatusCreated, entityResponse{ID: id})
+}
+
+func (a *API) handleUpdateGoal(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var req goalRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid payload")
+		return
+	}
+	if req.WorkspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace_id required")
+		return
+	}
+	if !a.authorizeWorkspace(w, r, req.WorkspaceID) {
+		return
+	}
+	if err := a.Repo.UpdateGoal(r.Context(), id, req.WorkspaceID, req.Title, req.Description, req.Period, req.Status, req.StartDate, req.EndDate); err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "goal not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to update goal")
+		return
+	}
+	writeJSON(w, http.StatusOK, entityResponse{ID: id})
+}
+
+func (a *API) handleDeleteGoal(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	workspaceID := r.URL.Query().Get("workspace_id")
+	if workspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace_id required")
+		return
+	}
+	if !a.authorizeWorkspace(w, r, workspaceID) {
+		return
+	}
+	if err := a.Repo.DeleteGoal(r.Context(), id, workspaceID); err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "goal not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to delete goal")
+		return
+	}
+	writeJSON(w, http.StatusOK, entityResponse{ID: id})
+}
+
+func (a *API) handleListTasks(w http.ResponseWriter, r *http.Request) {
+	workspaceID := r.URL.Query().Get("workspace_id")
+	if !a.authorizeWorkspace(w, r, workspaceID) {
+		return
+	}
+	tasks, err := a.Repo.ListTasks(r.Context(), workspaceID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list tasks")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"tasks": tasks})
+}
+
+func (a *API) handleCreateTask(w http.ResponseWriter, r *http.Request) {
+	var req taskRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid payload")
+		return
+	}
+	if req.Title == "" || req.WorkspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace_id and title required")
+		return
+	}
+	if !a.authorizeWorkspace(w, r, req.WorkspaceID) {
+		return
+	}
+	status := req.Status
+	if status == "" {
+		status = "open"
+	}
+	id, err := a.Repo.CreateTask(r.Context(), req.WorkspaceID, req.GoalID, req.Title, req.Description, req.DueDate, req.RepeatRule, req.Value, status)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create task")
+		return
+	}
+	writeJSON(w, http.StatusCreated, entityResponse{ID: id})
+}
+
+func (a *API) handleUpdateTask(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var req taskRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid payload")
+		return
+	}
+	if req.WorkspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace_id required")
+		return
+	}
+	if !a.authorizeWorkspace(w, r, req.WorkspaceID) {
+		return
+	}
+	if err := a.Repo.UpdateTask(r.Context(), id, req.WorkspaceID, req.GoalID, req.Title, req.Description, req.DueDate, req.RepeatRule, req.Value, req.Status); err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "task not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to update task")
+		return
+	}
+	writeJSON(w, http.StatusOK, entityResponse{ID: id})
+}
+
+func (a *API) handleDeleteTask(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	workspaceID := r.URL.Query().Get("workspace_id")
+	if workspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace_id required")
+		return
+	}
+	if !a.authorizeWorkspace(w, r, workspaceID) {
+		return
+	}
+	if err := a.Repo.DeleteTask(r.Context(), id, workspaceID); err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "task not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to delete task")
+		return
+	}
+	writeJSON(w, http.StatusOK, entityResponse{ID: id})
+}
+
+func (a *API) handleCompleteTask(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var req struct {
+		WorkspaceID string `json:"workspace_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid payload")
+		return
+	}
+	if req.WorkspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace_id required")
+		return
+	}
+	if !a.authorizeWorkspace(w, r, req.WorkspaceID) {
+		return
+	}
+	userID, _ := auth.UserIDFromContext(r.Context())
+	value, err := a.Repo.CompleteTask(r.Context(), id, req.WorkspaceID, userID)
+	if err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "task not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to complete task")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"earned": value})
+}
+
+func (a *API) handleListRewards(w http.ResponseWriter, r *http.Request) {
+	workspaceID := r.URL.Query().Get("workspace_id")
+	if !a.authorizeWorkspace(w, r, workspaceID) {
+		return
+	}
+	rewards, err := a.Repo.ListRewards(r.Context(), workspaceID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list rewards")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"rewards": rewards})
+}
+
+func (a *API) handleCreateReward(w http.ResponseWriter, r *http.Request) {
+	var req rewardRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid payload")
+		return
+	}
+	if req.Title == "" || req.WorkspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace_id and title required")
+		return
+	}
+	if !a.authorizeWorkspace(w, r, req.WorkspaceID) {
+		return
+	}
+	id, err := a.Repo.CreateReward(r.Context(), req.WorkspaceID, req.Title, req.Description, req.Cost, req.IsShared, req.CooldownHours)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create reward")
+		return
+	}
+	writeJSON(w, http.StatusCreated, entityResponse{ID: id})
+}
+
+func (a *API) handleUpdateReward(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var req rewardRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid payload")
+		return
+	}
+	if req.WorkspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace_id required")
+		return
+	}
+	if !a.authorizeWorkspace(w, r, req.WorkspaceID) {
+		return
+	}
+	if err := a.Repo.UpdateReward(r.Context(), id, req.WorkspaceID, req.Title, req.Description, req.Cost, req.IsShared, req.CooldownHours); err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "reward not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to update reward")
+		return
+	}
+	writeJSON(w, http.StatusOK, entityResponse{ID: id})
+}
+
+func (a *API) handleDeleteReward(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	workspaceID := r.URL.Query().Get("workspace_id")
+	if workspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace_id required")
+		return
+	}
+	if !a.authorizeWorkspace(w, r, workspaceID) {
+		return
+	}
+	if err := a.Repo.DeleteReward(r.Context(), id, workspaceID); err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "reward not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to delete reward")
+		return
+	}
+	writeJSON(w, http.StatusOK, entityResponse{ID: id})
+}
+
+func (a *API) handleBuyReward(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var req struct {
+		WorkspaceID string `json:"workspace_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid payload")
+		return
+	}
+	if req.WorkspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace_id required")
+		return
+	}
+	if !a.authorizeWorkspace(w, r, req.WorkspaceID) {
+		return
+	}
+	userID, _ := auth.UserIDFromContext(r.Context())
+	cost, err := a.Repo.BuyReward(r.Context(), id, req.WorkspaceID, userID)
+	if err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "reward not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to buy reward")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"spent": cost})
+}
+
+func (a *API) handleListAchievements(w http.ResponseWriter, r *http.Request) {
+	workspaceID := r.URL.Query().Get("workspace_id")
+	if !a.authorizeWorkspace(w, r, workspaceID) {
+		return
+	}
+	achievements, err := a.Repo.ListAchievements(r.Context(), workspaceID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list achievements")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"achievements": achievements})
+}
+
+func (a *API) handleCreateAchievement(w http.ResponseWriter, r *http.Request) {
+	var req achievementRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid payload")
+		return
+	}
+	if req.Title == "" || req.WorkspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace_id and title required")
+		return
+	}
+	if !a.authorizeWorkspace(w, r, req.WorkspaceID) {
+		return
+	}
+	id, err := a.Repo.CreateAchievement(r.Context(), req.WorkspaceID, req.Title, req.Description, req.ImageURL)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create achievement")
+		return
+	}
+	writeJSON(w, http.StatusCreated, entityResponse{ID: id})
+}
+
+func (a *API) handleUpdateAchievement(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var req achievementRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid payload")
+		return
+	}
+	if req.WorkspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace_id required")
+		return
+	}
+	if !a.authorizeWorkspace(w, r, req.WorkspaceID) {
+		return
+	}
+	if err := a.Repo.UpdateAchievement(r.Context(), id, req.WorkspaceID, req.Title, req.Description, req.ImageURL, req.AchievedAt); err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "achievement not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to update achievement")
+		return
+	}
+	writeJSON(w, http.StatusOK, entityResponse{ID: id})
+}
+
+func (a *API) handleDeleteAchievement(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	workspaceID := r.URL.Query().Get("workspace_id")
+	if workspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace_id required")
+		return
+	}
+	if !a.authorizeWorkspace(w, r, workspaceID) {
+		return
+	}
+	if err := a.Repo.DeleteAchievement(r.Context(), id, workspaceID); err != nil {
+		if errors.Is(err, repo.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "achievement not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to delete achievement")
+		return
+	}
+	writeJSON(w, http.StatusOK, entityResponse{ID: id})
+}
+
+func (a *API) handleSyncPull(w http.ResponseWriter, r *http.Request) {
+	workspaceID := r.URL.Query().Get("workspace_id")
+	if !a.authorizeWorkspace(w, r, workspaceID) {
+		return
+	}
+	sinceStr := r.URL.Query().Get("since")
+	if sinceStr == "" {
+		writeError(w, http.StatusBadRequest, "since required")
+		return
+	}
+	since, err := time.Parse(time.RFC3339, sinceStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid since")
+		return
+	}
+	changes, err := a.Repo.ListSyncChanges(r.Context(), workspaceID, since)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to sync")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"changes": changes, "server_time": time.Now().UTC()})
+}
+
+func (a *API) handleSyncPush(w http.ResponseWriter, r *http.Request) {
+	var req syncPushRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid payload")
+		return
+	}
+	if req.WorkspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace_id required")
+		return
+	}
+	if !a.authorizeWorkspace(w, r, req.WorkspaceID) {
+		return
+	}
+	for table, entries := range req.Changes {
+		for _, entry := range entries {
+			entry["workspace_id"] = req.WorkspaceID
+			if err := a.Repo.UpsertEntity(r.Context(), table, entry); err != nil {
+				writeError(w, http.StatusBadRequest, "failed to upsert")
+				return
+			}
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (a *API) authorizeWorkspace(w http.ResponseWriter, r *http.Request, workspaceID string) bool {
+	if workspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace_id required")
+		return false
+	}
+	userID, ok := auth.UserIDFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "missing user")
+		return false
+	}
+	allowed, err := a.Repo.UserInWorkspace(r.Context(), userID, workspaceID)
+	if err != nil || !allowed {
+		writeError(w, http.StatusForbidden, "not allowed")
+		return false
+	}
+	return true
+}
+
+func randomCode() string {
+	return base32Encoder().EncodeToString([]byte(time.Now().Format("20060102150405.000")))
+}
+
+func base32Encoder() *base32.Encoding {
+	return base32.StdEncoding.WithPadding(base32.NoPadding)
+}

--- a/internal/http/middleware.go
+++ b/internal/http/middleware.go
@@ -1,0 +1,47 @@
+package http
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"firegoals/internal/auth"
+)
+
+func loggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		next.ServeHTTP(w, r)
+		log.Printf("%s %s %s", r.Method, r.URL.Path, time.Since(start))
+	})
+}
+
+func corsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+		w.Header().Set("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (a *API) authMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token, ok := auth.TokenFromRequest(r)
+		if !ok {
+			writeError(w, http.StatusUnauthorized, "missing token")
+			return
+		}
+		claims, err := a.Auth.ParseToken(token)
+		if err != nil {
+			writeError(w, http.StatusUnauthorized, "invalid token")
+			return
+		}
+		ctx := auth.WithUserID(r.Context(), claims.UserID)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/internal/http/response.go
+++ b/internal/http/response.go
@@ -1,0 +1,20 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type apiError struct {
+	Message string `json:"message"`
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, apiError{Message: message})
+}

--- a/internal/http/router.go
+++ b/internal/http/router.go
@@ -1,0 +1,77 @@
+package http
+
+import (
+	"net/http"
+	"time"
+
+	"firegoals/internal/auth"
+	"firegoals/internal/repo"
+	"firegoals/internal/service"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+type API struct {
+	Repo    *repo.Repo
+	Service *service.Service
+	Auth    *auth.Manager
+}
+
+func (a *API) Router() http.Handler {
+	r := chi.NewRouter()
+	r.Use(middleware.RequestID)
+	r.Use(middleware.Recoverer)
+	r.Use(middleware.RealIP)
+	r.Use(middleware.Timeout(30 * time.Second))
+	r.Use(loggingMiddleware)
+	r.Use(corsMiddleware)
+
+	r.Get("/health", a.handleHealth)
+
+	r.Route("/auth", func(r chi.Router) {
+		r.Post("/register", a.handleRegister)
+		r.Post("/login", a.handleLogin)
+	})
+
+	r.Group(func(r chi.Router) {
+		r.Use(a.authMiddleware)
+		r.Get("/me", a.handleMe)
+		r.Get("/workspaces", a.handleListWorkspaces)
+		r.Post("/workspaces", a.handleCreateWorkspace)
+		r.Get("/workspaces/{id}/balance", a.handleWorkspaceBalance)
+		r.Post("/workspaces/{id}/invite", a.handleCreateInvite)
+		r.Post("/invites/accept", a.handleAcceptInvite)
+
+		r.Route("/goals", func(r chi.Router) {
+			r.Get("/", a.handleListGoals)
+			r.Post("/", a.handleCreateGoal)
+			r.Put("/{id}", a.handleUpdateGoal)
+			r.Delete("/{id}", a.handleDeleteGoal)
+		})
+		r.Route("/tasks", func(r chi.Router) {
+			r.Get("/", a.handleListTasks)
+			r.Post("/", a.handleCreateTask)
+			r.Put("/{id}", a.handleUpdateTask)
+			r.Delete("/{id}", a.handleDeleteTask)
+			r.Post("/{id}/complete", a.handleCompleteTask)
+		})
+		r.Route("/rewards", func(r chi.Router) {
+			r.Get("/", a.handleListRewards)
+			r.Post("/", a.handleCreateReward)
+			r.Put("/{id}", a.handleUpdateReward)
+			r.Delete("/{id}", a.handleDeleteReward)
+			r.Post("/{id}/buy", a.handleBuyReward)
+		})
+		r.Route("/achievements", func(r chi.Router) {
+			r.Get("/", a.handleListAchievements)
+			r.Post("/", a.handleCreateAchievement)
+			r.Put("/{id}", a.handleUpdateAchievement)
+			r.Delete("/{id}", a.handleDeleteAchievement)
+		})
+		r.Get("/sync", a.handleSyncPull)
+		r.Post("/sync", a.handleSyncPush)
+	})
+
+	return r
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,0 +1,131 @@
+package models
+
+import "time"
+
+type User struct {
+	ID           string    `json:"id"`
+	Email        string    `json:"email"`
+	PasswordHash string    `json:"-"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+type Workspace struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Type      string    `json:"type"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type WorkspaceMember struct {
+	WorkspaceID string    `json:"workspace_id"`
+	UserID      string    `json:"user_id"`
+	Role        string    `json:"role"`
+	Permissions string    `json:"permissions"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+type Goal struct {
+	ID          string     `json:"id"`
+	WorkspaceID string     `json:"workspace_id"`
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	Period      string     `json:"period"`
+	StartDate   *time.Time `json:"start_date"`
+	EndDate     *time.Time `json:"end_date"`
+	Status      string     `json:"status"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	DeletedAt   *time.Time `json:"deleted_at"`
+	Version     int        `json:"version"`
+}
+
+type Task struct {
+	ID          string     `json:"id"`
+	WorkspaceID string     `json:"workspace_id"`
+	GoalID      *string    `json:"goal_id"`
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	DueDate     *time.Time `json:"due_date"`
+	RepeatRule  *string    `json:"repeat_rule"`
+	Value       float64    `json:"value"`
+	Status      string     `json:"status"`
+	DoneAt      *time.Time `json:"done_at"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	DeletedAt   *time.Time `json:"deleted_at"`
+	Version     int        `json:"version"`
+}
+
+type Reward struct {
+	ID            string     `json:"id"`
+	WorkspaceID   string     `json:"workspace_id"`
+	Title         string     `json:"title"`
+	Description   string     `json:"description"`
+	Cost          float64    `json:"cost"`
+	IsShared      bool       `json:"is_shared"`
+	CooldownHours *int       `json:"cooldown_hours"`
+	CreatedAt     time.Time  `json:"created_at"`
+	UpdatedAt     time.Time  `json:"updated_at"`
+	DeletedAt     *time.Time `json:"deleted_at"`
+	Version       int        `json:"version"`
+}
+
+type RewardPurchase struct {
+	ID          string    `json:"id"`
+	WorkspaceID string    `json:"workspace_id"`
+	RewardID    string    `json:"reward_id"`
+	UserID      string    `json:"user_id"`
+	Cost        float64   `json:"cost"`
+	PurchasedAt time.Time `json:"purchased_at"`
+	Note        *string   `json:"note"`
+}
+
+type Achievement struct {
+	ID          string     `json:"id"`
+	WorkspaceID string     `json:"workspace_id"`
+	Title       string     `json:"title"`
+	Description string     `json:"description"`
+	ImageURL    *string    `json:"image_url"`
+	AchievedAt  *time.Time `json:"achieved_at"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+	DeletedAt   *time.Time `json:"deleted_at"`
+	Version     int        `json:"version"`
+}
+
+type Transaction struct {
+	ID          string    `json:"id"`
+	WorkspaceID string    `json:"workspace_id"`
+	UserID      *string   `json:"user_id"`
+	Type        string    `json:"type"`
+	Amount      float64   `json:"amount"`
+	Reason      string    `json:"reason"`
+	EntityType  *string   `json:"entity_type"`
+	EntityID    *string   `json:"entity_id"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+type WorkspaceBalance struct {
+	WorkspaceID string    `json:"workspace_id"`
+	Balance     float64   `json:"balance"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+type Session struct {
+	ID        string    `json:"id"`
+	UserID    string    `json:"user_id"`
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expires_at"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type Invite struct {
+	ID          string    `json:"id"`
+	WorkspaceID string    `json:"workspace_id"`
+	Code        string    `json:"code"`
+	CreatedBy   string    `json:"created_by"`
+	ExpiresAt   time.Time `json:"expires_at"`
+	CreatedAt   time.Time `json:"created_at"`
+}

--- a/internal/repo/repo.go
+++ b/internal/repo/repo.go
@@ -1,0 +1,442 @@
+package repo
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+var ErrNotFound = errors.New("not found")
+
+type Repo struct {
+	Pool *pgxpool.Pool
+}
+
+func New(pool *pgxpool.Pool) *Repo {
+	return &Repo{Pool: pool}
+}
+
+func (r *Repo) CreateUser(ctx context.Context, email, passwordHash string) (string, error) {
+	var id string
+	err := r.Pool.QueryRow(ctx, `INSERT INTO users (email, password_hash) VALUES ($1, $2) RETURNING id`, email, passwordHash).Scan(&id)
+	return id, err
+}
+
+func (r *Repo) GetUserByEmail(ctx context.Context, email string) (string, string, error) {
+	var id, hash string
+	err := r.Pool.QueryRow(ctx, `SELECT id, password_hash FROM users WHERE email=$1`, email).Scan(&id, &hash)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", "", ErrNotFound
+	}
+	return id, hash, err
+}
+
+func (r *Repo) GetUserByID(ctx context.Context, userID string) (string, string, error) {
+	var id, email string
+	err := r.Pool.QueryRow(ctx, `SELECT id, email FROM users WHERE id=$1`, userID).Scan(&id, &email)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", "", ErrNotFound
+	}
+	return id, email, err
+}
+
+func (r *Repo) CreateSession(ctx context.Context, userID, token string, expiresAt time.Time) error {
+	_, err := r.Pool.Exec(ctx, `INSERT INTO sessions (user_id, token, expires_at) VALUES ($1, $2, $3)`, userID, token, expiresAt)
+	return err
+}
+
+func (r *Repo) CreateWorkspace(ctx context.Context, name, workspaceType, ownerID string) (string, error) {
+	var id string
+	if err := r.Pool.QueryRow(ctx, `INSERT INTO workspaces (name, type) VALUES ($1, $2) RETURNING id`, name, workspaceType).Scan(&id); err != nil {
+		return "", err
+	}
+	_, err := r.Pool.Exec(ctx, `INSERT INTO workspace_members (workspace_id, user_id, role, permissions) VALUES ($1, $2, 'owner', '{"see_balance":true,"see_goals":true}'::jsonb)`, id, ownerID)
+	if err != nil {
+		return "", err
+	}
+	_, err = r.Pool.Exec(ctx, `INSERT INTO workspace_balance (workspace_id, balance) VALUES ($1, 0)`, id)
+	return id, err
+}
+
+func (r *Repo) AddWorkspaceMember(ctx context.Context, workspaceID, userID, role string) error {
+	_, err := r.Pool.Exec(ctx, `INSERT INTO workspace_members (workspace_id, user_id, role, permissions) VALUES ($1, $2, $3, '{"see_balance":true,"see_goals":true}'::jsonb) ON CONFLICT DO NOTHING`, workspaceID, userID, role)
+	return err
+}
+
+func (r *Repo) UserInWorkspace(ctx context.Context, userID, workspaceID string) (bool, error) {
+	var exists bool
+	err := r.Pool.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM workspace_members WHERE workspace_id=$1 AND user_id=$2)`, workspaceID, userID).Scan(&exists)
+	return exists, err
+}
+
+func (r *Repo) ListUserWorkspaces(ctx context.Context, userID string) ([]string, error) {
+	rows, err := r.Pool.Query(ctx, `SELECT workspace_id FROM workspace_members WHERE user_id=$1`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+func (r *Repo) CreateInvite(ctx context.Context, workspaceID, createdBy, code string, expiresAt time.Time) error {
+	_, err := r.Pool.Exec(ctx, `INSERT INTO workspace_invites (workspace_id, created_by, code, expires_at) VALUES ($1, $2, $3, $4)`, workspaceID, createdBy, code, expiresAt)
+	return err
+}
+
+func (r *Repo) GetInvite(ctx context.Context, code string) (string, time.Time, error) {
+	var workspaceID string
+	var expiresAt time.Time
+	err := r.Pool.QueryRow(ctx, `SELECT workspace_id, expires_at FROM workspace_invites WHERE code=$1`, code).Scan(&workspaceID, &expiresAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", time.Time{}, ErrNotFound
+	}
+	return workspaceID, expiresAt, err
+}
+
+func (r *Repo) CreateGoal(ctx context.Context, workspaceID, title, description, period, status string, startDate, endDate *time.Time) (string, error) {
+	var id string
+	err := r.Pool.QueryRow(ctx, `INSERT INTO goals (workspace_id, title, description, period, start_date, end_date, status) VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING id`, workspaceID, title, description, period, startDate, endDate, status).Scan(&id)
+	return id, err
+}
+
+func (r *Repo) UpdateGoal(ctx context.Context, id, workspaceID, title, description, period, status string, startDate, endDate *time.Time) error {
+	cmd, err := r.Pool.Exec(ctx, `UPDATE goals SET title=$1, description=$2, period=$3, status=$4, start_date=$5, end_date=$6, updated_at=now(), version=version+1 WHERE id=$7 AND workspace_id=$8`, title, description, period, status, startDate, endDate, id, workspaceID)
+	if err != nil {
+		return err
+	}
+	if cmd.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *Repo) DeleteGoal(ctx context.Context, id, workspaceID string) error {
+	cmd, err := r.Pool.Exec(ctx, `UPDATE goals SET deleted_at=now(), updated_at=now(), version=version+1 WHERE id=$1 AND workspace_id=$2`, id, workspaceID)
+	if err != nil {
+		return err
+	}
+	if cmd.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *Repo) ListGoals(ctx context.Context, workspaceID string) ([]map[string]any, error) {
+	rows, err := r.Pool.Query(ctx, `SELECT id, title, description, period, start_date, end_date, status, created_at, updated_at, deleted_at, version FROM goals WHERE workspace_id=$1`, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var res []map[string]any
+	for rows.Next() {
+		var id, title, description, period, status string
+		var startDate, endDate, deletedAt *time.Time
+		var createdAt, updatedAt time.Time
+		var version int
+		if err := rows.Scan(&id, &title, &description, &period, &startDate, &endDate, &status, &createdAt, &updatedAt, &deletedAt, &version); err != nil {
+			return nil, err
+		}
+		res = append(res, map[string]any{
+			"id": id, "workspace_id": workspaceID, "title": title, "description": description, "period": period, "start_date": startDate, "end_date": endDate, "status": status, "created_at": createdAt, "updated_at": updatedAt, "deleted_at": deletedAt, "version": version,
+		})
+	}
+	return res, rows.Err()
+}
+
+func (r *Repo) CreateTask(ctx context.Context, workspaceID string, goalID *string, title, description string, dueDate *time.Time, repeatRule *string, value float64, status string) (string, error) {
+	var id string
+	err := r.Pool.QueryRow(ctx, `INSERT INTO tasks (workspace_id, goal_id, title, description, due_date, repeat_rule, value, status) VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING id`, workspaceID, goalID, title, description, dueDate, repeatRule, value, status).Scan(&id)
+	return id, err
+}
+
+func (r *Repo) UpdateTask(ctx context.Context, id, workspaceID string, goalID *string, title, description string, dueDate *time.Time, repeatRule *string, value float64, status string) error {
+	cmd, err := r.Pool.Exec(ctx, `UPDATE tasks SET goal_id=$1, title=$2, description=$3, due_date=$4, repeat_rule=$5, value=$6, status=$7, updated_at=now(), version=version+1 WHERE id=$8 AND workspace_id=$9`, goalID, title, description, dueDate, repeatRule, value, status, id, workspaceID)
+	if err != nil {
+		return err
+	}
+	if cmd.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *Repo) CompleteTask(ctx context.Context, id, workspaceID, userID string) (float64, error) {
+	var value float64
+	cmd := r.Pool.QueryRow(ctx, `UPDATE tasks SET status='done', done_at=now(), updated_at=now(), version=version+1 WHERE id=$1 AND workspace_id=$2 RETURNING value`, id, workspaceID)
+	if err := cmd.Scan(&value); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return 0, ErrNotFound
+		}
+		return 0, err
+	}
+	_, err := r.Pool.Exec(ctx, `INSERT INTO transactions (workspace_id, user_id, type, amount, reason, entity_type, entity_id) VALUES ($1,$2,'earn',$3,'task completed','task',$4)`, workspaceID, userID, value, id)
+	if err != nil {
+		return 0, err
+	}
+	_, err = r.Pool.Exec(ctx, `UPDATE workspace_balance SET balance = balance + $1, updated_at=now() WHERE workspace_id=$2`, value, workspaceID)
+	return value, err
+}
+
+func (r *Repo) DeleteTask(ctx context.Context, id, workspaceID string) error {
+	cmd, err := r.Pool.Exec(ctx, `UPDATE tasks SET deleted_at=now(), updated_at=now(), version=version+1 WHERE id=$1 AND workspace_id=$2`, id, workspaceID)
+	if err != nil {
+		return err
+	}
+	if cmd.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *Repo) ListTasks(ctx context.Context, workspaceID string) ([]map[string]any, error) {
+	rows, err := r.Pool.Query(ctx, `SELECT id, goal_id, title, description, due_date, repeat_rule, value, status, done_at, created_at, updated_at, deleted_at, version FROM tasks WHERE workspace_id=$1`, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var res []map[string]any
+	for rows.Next() {
+		var id string
+		var goalID *string
+		var title, description, status string
+		var dueDate, doneAt, deletedAt *time.Time
+		var repeatRule *string
+		var value float64
+		var createdAt, updatedAt time.Time
+		var version int
+		if err := rows.Scan(&id, &goalID, &title, &description, &dueDate, &repeatRule, &value, &status, &doneAt, &createdAt, &updatedAt, &deletedAt, &version); err != nil {
+			return nil, err
+		}
+		res = append(res, map[string]any{
+			"id": id, "workspace_id": workspaceID, "goal_id": goalID, "title": title, "description": description, "due_date": dueDate, "repeat_rule": repeatRule, "value": value, "status": status, "done_at": doneAt, "created_at": createdAt, "updated_at": updatedAt, "deleted_at": deletedAt, "version": version,
+		})
+	}
+	return res, rows.Err()
+}
+
+func (r *Repo) CreateReward(ctx context.Context, workspaceID, title, description string, cost float64, isShared bool, cooldownHours *int) (string, error) {
+	var id string
+	err := r.Pool.QueryRow(ctx, `INSERT INTO rewards (workspace_id, title, description, cost, is_shared, cooldown_hours) VALUES ($1,$2,$3,$4,$5,$6) RETURNING id`, workspaceID, title, description, cost, isShared, cooldownHours).Scan(&id)
+	return id, err
+}
+
+func (r *Repo) UpdateReward(ctx context.Context, id, workspaceID, title, description string, cost float64, isShared bool, cooldownHours *int) error {
+	cmd, err := r.Pool.Exec(ctx, `UPDATE rewards SET title=$1, description=$2, cost=$3, is_shared=$4, cooldown_hours=$5, updated_at=now(), version=version+1 WHERE id=$6 AND workspace_id=$7`, title, description, cost, isShared, cooldownHours, id, workspaceID)
+	if err != nil {
+		return err
+	}
+	if cmd.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *Repo) DeleteReward(ctx context.Context, id, workspaceID string) error {
+	cmd, err := r.Pool.Exec(ctx, `UPDATE rewards SET deleted_at=now(), updated_at=now(), version=version+1 WHERE id=$1 AND workspace_id=$2`, id, workspaceID)
+	if err != nil {
+		return err
+	}
+	if cmd.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *Repo) ListRewards(ctx context.Context, workspaceID string) ([]map[string]any, error) {
+	rows, err := r.Pool.Query(ctx, `SELECT id, title, description, cost, is_shared, cooldown_hours, created_at, updated_at, deleted_at, version FROM rewards WHERE workspace_id=$1`, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var res []map[string]any
+	for rows.Next() {
+		var id, title, description string
+		var cost float64
+		var isShared bool
+		var cooldownHours *int
+		var createdAt, updatedAt time.Time
+		var deletedAt *time.Time
+		var version int
+		if err := rows.Scan(&id, &title, &description, &cost, &isShared, &cooldownHours, &createdAt, &updatedAt, &deletedAt, &version); err != nil {
+			return nil, err
+		}
+		res = append(res, map[string]any{
+			"id": id, "workspace_id": workspaceID, "title": title, "description": description, "cost": cost, "is_shared": isShared, "cooldown_hours": cooldownHours, "created_at": createdAt, "updated_at": updatedAt, "deleted_at": deletedAt, "version": version,
+		})
+	}
+	return res, rows.Err()
+}
+
+func (r *Repo) BuyReward(ctx context.Context, rewardID, workspaceID, userID string) (float64, error) {
+	var cost float64
+	if err := r.Pool.QueryRow(ctx, `SELECT cost FROM rewards WHERE id=$1 AND workspace_id=$2`, rewardID, workspaceID).Scan(&cost); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return 0, ErrNotFound
+		}
+		return 0, err
+	}
+	_, err := r.Pool.Exec(ctx, `INSERT INTO reward_purchases (workspace_id, reward_id, user_id, cost) VALUES ($1,$2,$3,$4)`, workspaceID, rewardID, userID, cost)
+	if err != nil {
+		return 0, err
+	}
+	_, err = r.Pool.Exec(ctx, `INSERT INTO transactions (workspace_id, user_id, type, amount, reason, entity_type, entity_id) VALUES ($1,$2,'spend',$3,'reward purchased','reward',$4)`, workspaceID, userID, cost, rewardID)
+	if err != nil {
+		return 0, err
+	}
+	_, err = r.Pool.Exec(ctx, `UPDATE workspace_balance SET balance = balance - $1, updated_at=now() WHERE workspace_id=$2`, cost, workspaceID)
+	return cost, err
+}
+
+func (r *Repo) CreateAchievement(ctx context.Context, workspaceID, title, description string, imageURL *string) (string, error) {
+	var id string
+	err := r.Pool.QueryRow(ctx, `INSERT INTO achievements (workspace_id, title, description, image_url) VALUES ($1,$2,$3,$4) RETURNING id`, workspaceID, title, description, imageURL).Scan(&id)
+	return id, err
+}
+
+func (r *Repo) UpdateAchievement(ctx context.Context, id, workspaceID, title, description string, imageURL *string, achievedAt *time.Time) error {
+	cmd, err := r.Pool.Exec(ctx, `UPDATE achievements SET title=$1, description=$2, image_url=$3, achieved_at=$4, updated_at=now(), version=version+1 WHERE id=$5 AND workspace_id=$6`, title, description, imageURL, achievedAt, id, workspaceID)
+	if err != nil {
+		return err
+	}
+	if cmd.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *Repo) DeleteAchievement(ctx context.Context, id, workspaceID string) error {
+	cmd, err := r.Pool.Exec(ctx, `UPDATE achievements SET deleted_at=now(), updated_at=now(), version=version+1 WHERE id=$1 AND workspace_id=$2`, id, workspaceID)
+	if err != nil {
+		return err
+	}
+	if cmd.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (r *Repo) ListAchievements(ctx context.Context, workspaceID string) ([]map[string]any, error) {
+	rows, err := r.Pool.Query(ctx, `SELECT id, title, description, image_url, achieved_at, created_at, updated_at, deleted_at, version FROM achievements WHERE workspace_id=$1`, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var res []map[string]any
+	for rows.Next() {
+		var id, title, description string
+		var imageURL *string
+		var achievedAt, deletedAt *time.Time
+		var createdAt, updatedAt time.Time
+		var version int
+		if err := rows.Scan(&id, &title, &description, &imageURL, &achievedAt, &createdAt, &updatedAt, &deletedAt, &version); err != nil {
+			return nil, err
+		}
+		res = append(res, map[string]any{
+			"id": id, "workspace_id": workspaceID, "title": title, "description": description, "image_url": imageURL, "achieved_at": achievedAt, "created_at": createdAt, "updated_at": updatedAt, "deleted_at": deletedAt, "version": version,
+		})
+	}
+	return res, rows.Err()
+}
+
+func (r *Repo) ListSyncChanges(ctx context.Context, workspaceID string, since time.Time) (map[string][]map[string]any, error) {
+	goals, err := r.queryEntity(ctx, `SELECT id, title, description, period, start_date, end_date, status, created_at, updated_at, deleted_at, version FROM goals WHERE workspace_id=$1 AND updated_at > $2`, workspaceID, since)
+	if err != nil {
+		return nil, err
+	}
+	tasks, err := r.queryEntity(ctx, `SELECT id, goal_id, title, description, due_date, repeat_rule, value, status, done_at, created_at, updated_at, deleted_at, version FROM tasks WHERE workspace_id=$1 AND updated_at > $2`, workspaceID, since)
+	if err != nil {
+		return nil, err
+	}
+	rewards, err := r.queryEntity(ctx, `SELECT id, title, description, cost, is_shared, cooldown_hours, created_at, updated_at, deleted_at, version FROM rewards WHERE workspace_id=$1 AND updated_at > $2`, workspaceID, since)
+	if err != nil {
+		return nil, err
+	}
+	achievements, err := r.queryEntity(ctx, `SELECT id, title, description, image_url, achieved_at, created_at, updated_at, deleted_at, version FROM achievements WHERE workspace_id=$1 AND updated_at > $2`, workspaceID, since)
+	if err != nil {
+		return nil, err
+	}
+	return map[string][]map[string]any{
+		"goals":        goals,
+		"tasks":        tasks,
+		"rewards":      rewards,
+		"achievements": achievements,
+	}, nil
+}
+
+func (r *Repo) queryEntity(ctx context.Context, query string, args ...any) ([]map[string]any, error) {
+	rows, err := r.Pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	fields := rows.FieldDescriptions()
+	var results []map[string]any
+	for rows.Next() {
+		values, err := rows.Values()
+		if err != nil {
+			return nil, err
+		}
+		entry := make(map[string]any)
+		for i, field := range fields {
+			entry[string(field.Name)] = values[i]
+		}
+		entry["workspace_id"] = args[0]
+		results = append(results, entry)
+	}
+	return results, rows.Err()
+}
+
+func (r *Repo) UpsertEntity(ctx context.Context, table string, payload map[string]any) error {
+	switch table {
+	case "goals":
+		_, err := r.Pool.Exec(ctx, `INSERT INTO goals (id, workspace_id, title, description, period, start_date, end_date, status, created_at, updated_at, deleted_at, version)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,COALESCE($9, now()),COALESCE($10, now()),$11,COALESCE($12, 1))
+			ON CONFLICT (id) DO UPDATE SET title=EXCLUDED.title, description=EXCLUDED.description, period=EXCLUDED.period, start_date=EXCLUDED.start_date, end_date=EXCLUDED.end_date, status=EXCLUDED.status, updated_at=EXCLUDED.updated_at, deleted_at=EXCLUDED.deleted_at, version=EXCLUDED.version
+			WHERE goals.updated_at < EXCLUDED.updated_at OR (goals.updated_at = EXCLUDED.updated_at AND goals.version < EXCLUDED.version)`,
+			payload["id"], payload["workspace_id"], payload["title"], payload["description"], payload["period"], payload["start_date"], payload["end_date"], payload["status"], payload["created_at"], payload["updated_at"], payload["deleted_at"], payload["version"])
+		return err
+	case "tasks":
+		_, err := r.Pool.Exec(ctx, `INSERT INTO tasks (id, workspace_id, goal_id, title, description, due_date, repeat_rule, value, status, done_at, created_at, updated_at, deleted_at, version)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,COALESCE($11, now()),COALESCE($12, now()),$13,COALESCE($14, 1))
+			ON CONFLICT (id) DO UPDATE SET goal_id=EXCLUDED.goal_id, title=EXCLUDED.title, description=EXCLUDED.description, due_date=EXCLUDED.due_date, repeat_rule=EXCLUDED.repeat_rule, value=EXCLUDED.value, status=EXCLUDED.status, done_at=EXCLUDED.done_at, updated_at=EXCLUDED.updated_at, deleted_at=EXCLUDED.deleted_at, version=EXCLUDED.version
+			WHERE tasks.updated_at < EXCLUDED.updated_at OR (tasks.updated_at = EXCLUDED.updated_at AND tasks.version < EXCLUDED.version)`,
+			payload["id"], payload["workspace_id"], payload["goal_id"], payload["title"], payload["description"], payload["due_date"], payload["repeat_rule"], payload["value"], payload["status"], payload["done_at"], payload["created_at"], payload["updated_at"], payload["deleted_at"], payload["version"])
+		return err
+	case "rewards":
+		_, err := r.Pool.Exec(ctx, `INSERT INTO rewards (id, workspace_id, title, description, cost, is_shared, cooldown_hours, created_at, updated_at, deleted_at, version)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,COALESCE($8, now()),COALESCE($9, now()),$10,COALESCE($11, 1))
+			ON CONFLICT (id) DO UPDATE SET title=EXCLUDED.title, description=EXCLUDED.description, cost=EXCLUDED.cost, is_shared=EXCLUDED.is_shared, cooldown_hours=EXCLUDED.cooldown_hours, updated_at=EXCLUDED.updated_at, deleted_at=EXCLUDED.deleted_at, version=EXCLUDED.version
+			WHERE rewards.updated_at < EXCLUDED.updated_at OR (rewards.updated_at = EXCLUDED.updated_at AND rewards.version < EXCLUDED.version)`,
+			payload["id"], payload["workspace_id"], payload["title"], payload["description"], payload["cost"], payload["is_shared"], payload["cooldown_hours"], payload["created_at"], payload["updated_at"], payload["deleted_at"], payload["version"])
+		return err
+	case "achievements":
+		_, err := r.Pool.Exec(ctx, `INSERT INTO achievements (id, workspace_id, title, description, image_url, achieved_at, created_at, updated_at, deleted_at, version)
+			VALUES ($1,$2,$3,$4,$5,$6,COALESCE($7, now()),COALESCE($8, now()),$9,COALESCE($10, 1))
+			ON CONFLICT (id) DO UPDATE SET title=EXCLUDED.title, description=EXCLUDED.description, image_url=EXCLUDED.image_url, achieved_at=EXCLUDED.achieved_at, updated_at=EXCLUDED.updated_at, deleted_at=EXCLUDED.deleted_at, version=EXCLUDED.version
+			WHERE achievements.updated_at < EXCLUDED.updated_at OR (achievements.updated_at = EXCLUDED.updated_at AND achievements.version < EXCLUDED.version)`,
+			payload["id"], payload["workspace_id"], payload["title"], payload["description"], payload["image_url"], payload["achieved_at"], payload["created_at"], payload["updated_at"], payload["deleted_at"], payload["version"])
+		return err
+	default:
+		return errors.New("unknown table")
+	}
+}
+
+func (r *Repo) GetWorkspaceBalance(ctx context.Context, workspaceID string) (float64, error) {
+	var balance float64
+	err := r.Pool.QueryRow(ctx, `SELECT balance FROM workspace_balance WHERE workspace_id=$1`, workspaceID).Scan(&balance)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return 0, ErrNotFound
+	}
+	return balance, err
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"time"
+
+	"firegoals/internal/auth"
+	"firegoals/internal/repo"
+)
+
+type Service struct {
+	Repo      *repo.Repo
+	Auth      *auth.Manager
+	TokenTTL  time.Duration
+	RefreshTT time.Duration
+}
+
+func New(repo *repo.Repo, authManager *auth.Manager) *Service {
+	return &Service{Repo: repo, Auth: authManager, TokenTTL: time.Hour, RefreshTT: 7 * 24 * time.Hour}
+}
+
+func (s *Service) Register(ctx context.Context, email, password string) (string, error) {
+	hash, err := s.Auth.HashPassword(password)
+	if err != nil {
+		return "", err
+	}
+	userID, err := s.Repo.CreateUser(ctx, email, hash)
+	if err != nil {
+		return "", err
+	}
+	_, err = s.Repo.CreateWorkspace(ctx, "Personal", "personal", userID)
+	if err != nil {
+		return "", err
+	}
+	return userID, nil
+}
+
+func (s *Service) Login(ctx context.Context, email, password string) (string, string, error) {
+	userID, hash, err := s.Repo.GetUserByEmail(ctx, email)
+	if err != nil {
+		return "", "", err
+	}
+	if err := s.Auth.ComparePassword(hash, password); err != nil {
+		return "", "", errors.New("invalid credentials")
+	}
+	accessToken, err := s.Auth.GenerateToken(userID, s.TokenTTL)
+	if err != nil {
+		return "", "", err
+	}
+	refreshToken, err := s.generateRefreshToken()
+	if err != nil {
+		return "", "", err
+	}
+	if err := s.Repo.CreateSession(ctx, userID, refreshToken, time.Now().Add(s.RefreshTT)); err != nil {
+		return "", "", err
+	}
+	return accessToken, refreshToken, nil
+}
+
+func (s *Service) generateRefreshToken() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}

--- a/migrations/0001_init.sql
+++ b/migrations/0001_init.sql
@@ -1,0 +1,130 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE users (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  email text UNIQUE NOT NULL,
+  password_hash text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE workspaces (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  type text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE workspace_members (
+  workspace_id uuid REFERENCES workspaces(id) ON DELETE CASCADE,
+  user_id uuid REFERENCES users(id) ON DELETE CASCADE,
+  role text NOT NULL,
+  permissions jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (workspace_id, user_id)
+);
+
+CREATE TABLE goals (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id uuid REFERENCES workspaces(id) ON DELETE CASCADE,
+  title text NOT NULL,
+  description text NOT NULL DEFAULT '',
+  period text NOT NULL,
+  start_date date NULL,
+  end_date date NULL,
+  status text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz NULL,
+  version int NOT NULL DEFAULT 1
+);
+
+CREATE TABLE tasks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id uuid REFERENCES workspaces(id) ON DELETE CASCADE,
+  goal_id uuid REFERENCES goals(id) ON DELETE SET NULL,
+  title text NOT NULL,
+  description text NOT NULL DEFAULT '',
+  due_date date NULL,
+  repeat_rule text NULL,
+  value numeric(10,2) NOT NULL DEFAULT 0,
+  status text NOT NULL,
+  done_at timestamptz NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz NULL,
+  version int NOT NULL DEFAULT 1
+);
+
+CREATE TABLE rewards (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id uuid REFERENCES workspaces(id) ON DELETE CASCADE,
+  title text NOT NULL,
+  description text NOT NULL DEFAULT '',
+  cost numeric(10,2) NOT NULL,
+  is_shared boolean NOT NULL DEFAULT false,
+  cooldown_hours int NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz NULL,
+  version int NOT NULL DEFAULT 1
+);
+
+CREATE TABLE reward_purchases (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id uuid REFERENCES workspaces(id) ON DELETE CASCADE,
+  reward_id uuid REFERENCES rewards(id) ON DELETE CASCADE,
+  user_id uuid REFERENCES users(id) ON DELETE SET NULL,
+  cost numeric(10,2) NOT NULL,
+  purchased_at timestamptz NOT NULL DEFAULT now(),
+  note text NULL
+);
+
+CREATE TABLE achievements (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id uuid REFERENCES workspaces(id) ON DELETE CASCADE,
+  title text NOT NULL,
+  description text NOT NULL DEFAULT '',
+  image_url text NULL,
+  achieved_at timestamptz NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz NULL,
+  version int NOT NULL DEFAULT 1
+);
+
+CREATE TABLE transactions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id uuid REFERENCES workspaces(id) ON DELETE CASCADE,
+  user_id uuid REFERENCES users(id) ON DELETE SET NULL,
+  type text NOT NULL,
+  amount numeric(10,2) NOT NULL,
+  reason text NOT NULL,
+  entity_type text NULL,
+  entity_id uuid NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE workspace_balance (
+  workspace_id uuid PRIMARY KEY REFERENCES workspaces(id) ON DELETE CASCADE,
+  balance numeric(10,2) NOT NULL DEFAULT 0,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE sessions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES users(id) ON DELETE CASCADE,
+  token text NOT NULL,
+  expires_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE workspace_invites (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id uuid REFERENCES workspaces(id) ON DELETE CASCADE,
+  code text UNIQUE NOT NULL,
+  created_by uuid REFERENCES users(id) ON DELETE SET NULL,
+  expires_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,11 @@
+services:
+  - type: web
+    name: firegoals-api
+    env: docker
+    plan: free
+    healthCheckPath: /health
+    envVars:
+      - key: DATABASE_URL
+        sync: false
+      - key: JWT_SECRET
+        sync: false


### PR DESCRIPTION
### Motivation
- Make the repository GitHub-friendly by excluding binaries, build outputs, node modules, caches and editor files with a proper repository-level `.gitignore` for a Go + frontend project.
- Remove generated/public PWA assets and service worker registration so the repository keeps only source code, config and documentation rather than build artifacts.

### Description
- Add a comprehensive `.gitignore` that excludes common Go binaries and build artifacts, frontend `node_modules`, caches, `dist`/`build` outputs, `public/` (PWA assets), log/temp files and IDE directories using a single top-level `/.gitignore` file.
- Delete the PWA `frontend/public` assets (`icon-192.png`, `icon-512.png`, `manifest.json`, `sw.js`) and remove the manifest link and service worker registration by updating `frontend/index.html` and `frontend/src/main.tsx`.
- Keep only source and config files (backend Go sources under `internal/`, `cmd/server`, `migrations/`, frontend `src/`, `package.json`, `vite`/`tsconfig` files, `README.md`, `Dockerfile`, etc.).
- Commit the changes and remove generated public files from the repository history in the working tree.

### Testing
- No automated tests were run for this change.
- A repository status and file listing were inspected after the changes to verify that `frontend/public` assets were removed and the new `/.gitignore` is present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d1e419d248321868cc0c209be6e7f)